### PR TITLE
[css-size-shorthand] Prevent size shorthand from being parsed in @page context

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -2175,6 +2175,10 @@ inline bool PropertyParserCustom::consumeMarkerShorthand(CSSParserTokenRange& ra
 
 inline bool PropertyParserCustom::consumeSizeShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
 {
+    if (state.currentRule == StyleRuleType::Page) {
+        // Do not parse size shorthand in @page context; let it be handled as a page-size descriptor.
+        return false;
+    }
     ASSERT(state.currentProperty == shorthand.id());
     ASSERT(shorthand.length() == 2);
     auto longhands = shorthand.properties();


### PR DESCRIPTION
#### 8ddae4f9d1bd0a3bcec7ebeb4e66346787e1b2b8
<pre>
[css-size-shorthand] Prevent size shorthand from being parsed in @page context
</pre>